### PR TITLE
remove future dependency

### DIFF
--- a/ez_setup.py
+++ b/ez_setup.py
@@ -13,8 +13,6 @@ the appropriate options to ``use_setuptools()``.
 
 This file can also be run as a script to install or upgrade setuptools.
 """
-from future import standard_library
-standard_library.install_aliases()
 import os
 import shutil
 import sys


### PR DESCRIPTION
having the future dependency does not make sense in my opinion.

I've tested the installation (and test in the test folder) on both python 2.7 and 3.7 - and there is no difference if `future` is used during the installation or if the code for it is removed.

I hope you'll be able to update the pip version soon, as we're hoping to depend on this library for an upcomming feature in our trading bot (relevant PR [here](https://github.com/freqtrade/freqtrade/pull/1229)

Unfortunately, it's very inconvenient to have to install "future" on python3, even though none of it's features are used.

Any questions let me know
