### PR TITLE
use oldest-supported-numpy as build requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
 # Minimum requirements for the build system to execute.
-requires = ["setuptools", "numpy>=1.13.0", "wheel"]  # PEP 508 specifications.
+requires = ["setuptools", "oldest-supported-numpy", "wheel"]  # PEP 508 specifications.


### PR DESCRIPTION
use `oldest-supported-numpy` for build requirements.
Explanation: https://github.com/pypa/pip/issues/9542#issuecomment-771424399

Otherwise due to a pip-bug, at build time, the latest numpy is installed, which can break if the environment uses a older pinned version.

in https://github.com/pypa/pip/issues/9542, I've posted a snippet to recreate the faulty behavior with the current version.
As proposed there, using `oldest-supported-numpy` should fix this, as older binaries work with newer versions:


> The reason to use the oldest available Numpy version as a build-time dependency is because of ABI compatibility. Binaries compiled with old Numpy versions are binary compatible with newer Numpy versions, but not vice versa.

[Source](https://pypi.org/project/oldest-supported-numpy/)